### PR TITLE
Many small improvements, and new welcome page at /

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -59,6 +59,10 @@ get '/forum/:username/:repo_name' do
   erb :index
 end
 
+get '/forum/:username/:repo_name/' do
+  redirect "/forum/#{params[:username]}/#{params[:repo_name]}"
+end
+
 get '/forum/:username/:repo_name/new' do
   authenticate!
   @repo_string = "#{params[:username]}/#{params[:repo_name]}"

--- a/app.rb
+++ b/app.rb
@@ -15,11 +15,9 @@ register Sinatra::Auth::Github
 markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, {autolink: true})
 
 def which_github_client()
-  ''' 
-    Which github client to use?
-    Use the users github api limit if they are logged in
-    Use ours for all the lurkers
-  '''
+  # Which github client to use?
+  # Use the users github api limit if they are logged in
+  # Use ours for all the lurkers
   if authenticated?
     client = github_user.api
   end
@@ -48,9 +46,7 @@ get '/forum/signout' do
 end
 
 get '/forum/:username/:repo_name' do
-  '''
-    A list of all the discussions happening in the main repo.
-  '''
+  # A list of all the discussions happening in the main repo.
   client = which_github_client()
   @repo_string = "#{params[:username]}/#{params[:repo_name]}"
   @repo = client.repository(@repo_string)

--- a/app.rb
+++ b/app.rb
@@ -27,6 +27,10 @@ def which_github_client()
   return client
 end
 
+get '/' do
+  erb :welcome
+end
+
 get '/forum' do
   redirect '/forum/codeforamerica/forum'
 end

--- a/app.rb
+++ b/app.rb
@@ -12,7 +12,7 @@ set :github_options, {
 }
 
 register Sinatra::Auth::Github
-markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, extensions = {autolink: true})
+markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, {autolink: true})
 
 def which_github_client()
   ''' 

--- a/views/welcome.erb
+++ b/views/welcome.erb
@@ -1,0 +1,25 @@
+<div class="top">
+  <h2>Welcome!</h2>
+</div>
+
+<h4>What is this?</h4>
+<p>This site provides a simplified interface for GitHub Issues, intended to make it easier for those new to GitHub to participate in discussions happening on projects.</p>
+
+<h4>How to use it</h4>
+<p>Explore a project's discussions by putting the project name in the URL like this:
+  <br>
+  /forum/USERNAME/REPONAME</p>
+<p>For example, to view this project, you would go to:
+  <br>
+  <a href="http://cfa-forum.herokuapp.com/forum/codeforamerica/forum">http://cfa-forum.herokuapp.com/forum/codeforamerica/forum</a></p>
+
+<h4>How do I participate in discussions?</h4>
+<p>To comment, you need to be signed in to your GitHub account. If you don't have one, head on over to the <a href="/forum/signup">"Sign up"</a> page and set up a free account in about a minute!</p>
+
+<h4>Project details</h4>
+<p>To learn more about this project or contribute, head on over to:
+  <br>
+  <a href="https://github.com/codeforamerica/forum">https://github.com/codeforamerica/forum</a></p>
+
+<div class="clear"></div>
+


### PR DESCRIPTION
A bunch of small improvements:
- Fix syntax of markdown library instantiation
- Convert comments from Pythonic to Rubyist
- Redirect /forum/username/reponame/ (/ at end) to the route without the / at end, so that it works

Most importantly:
- Add welcome page and root route for it

That welcome page looks like this currently:

![screen shot 2015-03-15 at 8 39 58 pm](https://cloud.githubusercontent.com/assets/994938/6660294/793652d0-cb53-11e4-838b-67e50bf4843a.png)
